### PR TITLE
Enhance PHP version requirement definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "bin/happy-holidays.php"
   ],
   "require": {
-    "php": ">7.0",
+    "php": "^7.4",
     "league/climate": "^3.4"
   },
   "require-dev": {


### PR DESCRIPTION
# Changed log
- The `php-7.0` has been unsupported from official PHP team.
- The currently supported PHP version is `7.1`.

# References
- https://www.php.net/supported-versions.php